### PR TITLE
Add support for group steps

### DIFF
--- a/cmd/buildkite-signed-pipeline/signer_test.go
+++ b/cmd/buildkite-signed-pipeline/signer_test.go
@@ -75,6 +75,25 @@ func TestSigningCommandWithPlugins(t *testing.T) {
 	assert.Equal(t, "llamas", sig)
 }
 
+func TestSigningCommandWithGroup(t *testing.T) {
+	jsonPipeline := `{"steps":[{"group":"Tests","steps":[{"command":"echo pass"}]}]}`
+
+	var parsed interface{}
+	if err := json.Unmarshal([]byte(jsonPipeline), &parsed); err != nil {
+		t.Fatal(err)
+	}
+
+	signer := NewSharedSecretSigner("secret-llamas")
+
+	signed, err := signer.Sign(parsed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	j, err := json.Marshal(signed)
+	assert.Equal(t, `{"steps":[{"group":"Tests","steps":[{"command":"echo pass","env":{"STEP_SIGNATURE":"sha256:2c3cb7057477c9630e26532ab6b1707fffc4df3efeb6488bcd9ff2784e1de6fa"}}]}]}`, string(j))
+}
+
 func mapInto(dest interface{}, source interface{}) error {
 	jsonBytes, err := json.Marshal(source)
 	if err != nil {


### PR DESCRIPTION
This relates to #40 by implementing functionality to handle `group` steps.

A test was added to verify the new logic and I've tested it manually locally and it generates a valid signature that verifies successfully.

This is the first contribution to this repo and combined with all the interfaces and reflection I'm not sure I've done it very "nicely". But I've tried to document it where I can so anyone else might have a better go of understanding whats going on. Perhaps seasoned Go developers would be fine with how it was, but I envisage this will be supported for a long time with large gaps between - enough time to forget the intricacies so the comments will hopefully help in that case.
